### PR TITLE
chart: add better error msg when brigade api token is missing

### DIFF
--- a/charts/brigade-acr-gateway/templates/secret.yaml
+++ b/charts/brigade-acr-gateway/templates/secret.yaml
@@ -6,4 +6,8 @@ metadata:
     {{- include "gateway.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{- if .Values.brigade.apiToken }}
   brigadeAPIToken: {{ .Values.brigade.apiToken }}
+  {{- else }}
+    {{ fail "Value MUST be specified for brigade.apiToken" }}
+  {{- end }}


### PR DESCRIPTION
Signed-off-by: Kent Rancourt <kent.rancourt@microsoft.com>