### PR TITLE
minor test improvements

### DIFF
--- a/golangci.yaml
+++ b/golangci.yaml
@@ -16,7 +16,6 @@ linters:
   - gocyclo
   - gofmt
   - goimports
-  - golint
   - gosec
   - govet
   - lll
@@ -24,6 +23,7 @@ linters:
   - misspell
   - nakedret
   - prealloc
+  - revive
   - unconvert
   - unparam
   - unused
@@ -61,9 +61,6 @@ linters-settings:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
     local-prefixes: github.com/org/project
-  golint:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0.8
   govet:
     # report about shadowed variables
     check-shadowing: true

--- a/internal/webhooks/service_test.go
+++ b/internal/webhooks/service_test.go
@@ -11,13 +11,14 @@ import (
 )
 
 func TestNewService(t *testing.T) {
-	s := NewService( // nolint: forcetypeassert
+	s, ok := NewService(
 		// Totally unusable client that is enough to fulfill the dependencies for
 		// this test...
 		&coreTesting.MockEventsClient{
 			LogsClient: &coreTesting.MockLogsClient{},
 		},
 	).(*service)
+	require.True(t, ok)
 	require.NotNil(t, s.eventsClient)
 }
 

--- a/internal/webhooks/token_filter_test.go
+++ b/internal/webhooks/token_filter_test.go
@@ -17,8 +17,8 @@ func TestNewTokenFilterConfig(t *testing.T) {
 
 func TestAddToken(t *testing.T) {
 	const testToken = "foo"
-	// nolint: forcetypeassert
-	config := NewTokenFilterConfig().(*tokenFilterConfig)
+	config, ok := NewTokenFilterConfig().(*tokenFilterConfig)
+	require.True(t, ok)
 	require.Empty(t, config.hashedTokens)
 	config.AddToken(testToken)
 	require.Len(t, config.hashedTokens, 1)
@@ -35,7 +35,8 @@ func TestGetHashedTokens(t *testing.T) {
 
 func TestNewTokenFilter(t *testing.T) {
 	testConfig := NewTokenFilterConfig()
-	filter := NewTokenFilter(testConfig).(*tokenFilter) // nolint: forcetypeassert
+	filter, ok := NewTokenFilter(testConfig).(*tokenFilter)
+	require.True(t, ok)
 	require.Equal(t, testConfig, filter.config)
 }
 
@@ -47,7 +48,7 @@ func TestTokenFilter(t *testing.T) {
 		name       string
 		filter     *tokenFilter
 		setup      func() *http.Request
-		assertions func(handlerCalled bool, rr *httptest.ResponseRecorder)
+		assertions func(handlerCalled bool, r *http.Response)
 	}{
 		{
 			name: "valid token provided",
@@ -60,8 +61,8 @@ func TestTokenFilter(t *testing.T) {
 				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", testToken))
 				return req
 			},
-			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusOK, rr.Code)
+			assertions: func(handlerCalled bool, r *http.Response) {
+				require.Equal(t, http.StatusOK, r.StatusCode)
 				require.True(t, handlerCalled)
 			},
 		},
@@ -75,8 +76,8 @@ func TestTokenFilter(t *testing.T) {
 				require.NoError(t, err)
 				return req
 			},
-			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusForbidden, rr.Code)
+			assertions: func(handlerCalled bool, r *http.Response) {
+				require.Equal(t, http.StatusForbidden, r.StatusCode)
 				require.False(t, handlerCalled)
 			},
 		},
@@ -91,8 +92,8 @@ func TestTokenFilter(t *testing.T) {
 				req.Header.Add("Authorization", "Bearer bogus-token")
 				return req
 			},
-			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusForbidden, rr.Code)
+			assertions: func(handlerCalled bool, r *http.Response) {
+				require.Equal(t, http.StatusForbidden, r.StatusCode)
 				require.False(t, handlerCalled)
 			},
 		},
@@ -106,7 +107,9 @@ func TestTokenFilter(t *testing.T) {
 				handlerCalled = true
 				w.WriteHeader(http.StatusOK)
 			})(rr, req)
-			testCase.assertions(handlerCalled, rr)
+			res := rr.Result()
+			defer res.Body.Close()
+			testCase.assertions(handlerCalled, res)
 		})
 	}
 }


### PR DESCRIPTION
A follow up to #26 

This PR replaces a deprecated linter and also improves tests slightly by remediating a few linting issues instead of sweeping them under the rug.

This PR also fixes test cases where assertion functions took an `*httptest.ResponseRecorder` argument. `*http.Response`, which is more common and familiar type, is used instead. It should improve the overall readability of the tests.