### PR TITLE
upgrade to brigadecore/go-tools:v0.8.0 -- includes go 1.18

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -1,6 +1,6 @@
 import { events, Event, Job, ConcurrentGroup, SerialGroup, Container } from "@brigadecore/brigadier"
 
-const goImg = "brigadecore/go-tools:v0.6.0"
+const goImg = "brigadecore/go-tools:v0.8.0"
 const dindImg = "docker:20.10.9-dind"
 const dockerClientImg = "brigadecore/docker-tools:v0.3.0"
 const helmImg = "brigadecore/helm-tools:v0.4.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.6.0 as builder
+FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.8.0 as builder
 
 ARG VERSION
 ARG COMMIT

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty --match=NeVeRmAtC
 
 ifneq ($(SKIP_DOCKER),true)
 	PROJECT_ROOT := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-	GO_DEV_IMAGE := brigadecore/go-tools:v0.6.0
+	GO_DEV_IMAGE := brigadecore/go-tools:v0.8.0
 
 	GO_DOCKER_CMD := docker run \
 		-it \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brigadecore/brigade-acr-gateway
 
-go 1.17
+go 1.18
 
 require (
 	github.com/brigadecore/brigade-foundations v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -26,7 +26,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -6,7 +6,7 @@ run:
 linters:
   disable-all: true
   enable:
-  - bodyclose
+  # - bodyclose # Not yet working with Go 1.18
   - depguard
   # - dupl
   - errcheck
@@ -25,8 +25,8 @@ linters:
   - prealloc
   - revive
   - unconvert
-  - unparam
-  - unused
+  # - unparam # Not yet working with Go 1.18
+  # - unused # Not yet working with Go 1.18
 
 # all available settings for all linters
 linters-settings:

--- a/internal/webhooks/token_filter_test.go
+++ b/internal/webhooks/token_filter_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 func TestNewTokenFilterConfig(t *testing.T) {
-	config := NewTokenFilterConfig()
-	require.NotNil(t, config.(*tokenFilterConfig).hashedTokens)
+	config, ok := NewTokenFilterConfig().(*tokenFilterConfig)
+	require.True(t, ok)
+	require.NotNil(t, config.hashedTokens)
 }
 
 func TestAddToken(t *testing.T) {


### PR DESCRIPTION
Fixes #54 