### PR TITLE
release process: fix image signing

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -126,7 +126,7 @@ const buildJob = (event: Event, version?: string) => {
     const keyDir = "~/.docker/trust/private"
     const keyFile = `${keyDir}/${secrets.imageSigningKeyHash}.key`
     signingCommands = `mkdir -p ${keyDir} && chmod 700 ${keyDir} && ` +
-      `printf $BASE64_IMAGE_SIGNING_KEY | base64 -D > ${keyFile} && ` +
+      `printf $BASE64_IMAGE_SIGNING_KEY | base64 -d > ${keyFile} && ` +
       `docker trust key load --name ${registryUsername} ${keyFile} && `
   }
   if (registry) {


### PR DESCRIPTION
Fixes an issue with #56 

I guess I'm used to the BSD implementation of `base64`. The `docker-tools` image has the GNU implementation...