### PR TITLE
release: fix signing key file permissions

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -126,7 +126,7 @@ const buildJob = (event: Event, version?: string) => {
     const keyDir = "~/.docker/trust/private"
     const keyFile = `${keyDir}/${secrets.imageSigningKeyHash}.key`
     signingCommands = `mkdir -p ${keyDir} && chmod 700 ${keyDir} && ` +
-      `printf $BASE64_IMAGE_SIGNING_KEY | base64 -d > ${keyFile} && ` +
+      `printf $BASE64_IMAGE_SIGNING_KEY | base64 -d > ${keyFile} && chmod 600 ${keyFile} && ` +
       `docker trust key load --name ${registryUsername} ${keyFile} && `
   }
   if (registry) {


### PR DESCRIPTION
Fixing this:

```
Loading key from "/root/.docker/trust/private/2f41aa6fd9326a09eea76bfce528908b271a82f2c387a26fca2d3f3925b9b2e2.key"...
refusing to load key from /root/.docker/trust/private/2f41aa6fd9326a09eea76bfce528908b271a82f2c387a26fca2d3f3925b9b2e2.key: private key file /root/.docker/trust/private/2f41aa6fd9326a09eea76bfce528908b271a82f2c387a26fca2d3f3925b9b2e2.key must not be readable or writable by others
```